### PR TITLE
Update autofix.yml

### DIFF
--- a/.github/workflows/autofix.yml
+++ b/.github/workflows/autofix.yml
@@ -62,4 +62,4 @@ jobs:
 
       # Commit and push any autofixes
       - name: Commit autofixes
-        uses: autofix-ci/action@551dded8c6cc8a1054039c8bc0b8b48c51dfc6ef
+        uses: autofix-ci/action@635ffb0c9798bd160680f18fd73371e355b85f27


### PR DESCRIPTION
This pull request includes a small update to the `.github/workflows/autofix.yml` file. The change updates the version of the `autofix-ci/action` used for committing autofixes to a newer commit hash.

* [`.github/workflows/autofix.yml`](diffhunk://#diff-89b476612e9731e1d69620da47f8939f627c347fa6575984daa6b71a4077dab4L65-R65): Updated the `autofix-ci/action` version from `551dded8c6cc8a1054039c8bc0b8b48c51dfc6ef` to `635ffb0c9798bd160680f18fd73371e355b85f27`.